### PR TITLE
Adding RSS feed & sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,6 +15,8 @@ import {
 } from './src/remark/directives';
 import remarkOnlyStrong from './src/remark/only-strong';
 import svgr from 'vite-plugin-svgr';
+import sitemap from '@astrojs/sitemap';
+
 
 // https://astro.build/config
 export default defineConfig({
@@ -37,6 +39,10 @@ export default defineConfig({
     mdx(),
     react(),
     dotHtmlRedirects(),
+    sitemap({
+      filter: (page) => page !== 'https://unitary.foundation/test/' &&
+        page !== 'https://unitary.foundation/author/image/',
+    }),
   ],
   markdown: {
     remarkPlugins: [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@astrojs/mdx": "^4.3.0",
     "@astrojs/react": "4.3.0",
     "@astrojs/rss": "^4.0.12",
+    "@astrojs/sitemap": "^3.4.1",
     "@astrojs/tailwind": "6.0.2",
     "@cloudinary/url-gen": "^1.21.0",
     "@emotion/css": "^11.13.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@astrojs/rss':
         specifier: ^4.0.12
         version: 4.0.12
+      '@astrojs/sitemap':
+        specifier: ^3.4.1
+        version: 3.4.1
       '@astrojs/tailwind':
         specifier: 6.0.2
         version: 6.0.2(astro@5.9.4(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(sass@1.86.3)(typescript@5.8.3)(yaml@2.7.1))(tailwindcss@3.4.17)
@@ -254,6 +257,9 @@ packages:
 
   '@astrojs/rss@4.0.12':
     resolution: {integrity: sha512-O5yyxHuDVb6DQ6VLOrbUVFSm+NpObulPxjs6XT9q3tC+RoKbN4HXMZLpv0LvXd1qdAjzVgJ1NFD+zKHJNDXikw==}
+
+  '@astrojs/sitemap@3.4.1':
+    resolution: {integrity: sha512-VjZvr1e4FH6NHyyHXOiQgLiw94LnCVY4v06wN/D0gZKchTMkg71GrAHJz81/huafcmavtLkIv26HnpfDq6/h/Q==}
 
   '@astrojs/tailwind@6.0.2':
     resolution: {integrity: sha512-j3mhLNeugZq6A8dMNXVarUa8K6X9AW+QHU9u3lKNrPLMHhOQ0S7VeWhHwEeJFpEK1BTKEUY1U78VQv2gN6hNGg==}
@@ -1507,6 +1513,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@17.0.45':
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+
   '@types/node@22.14.1':
     resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
 
@@ -1526,6 +1535,9 @@ packages:
 
   '@types/sanitize-html@2.15.0':
     resolution: {integrity: sha512-71Z6PbYsVKfp4i6Jvr37s5ql6if1Q/iJQT80NbaSi7uGaG8CqBMXP0pk/EsURAOuGdk5IJCd/vnzKrR7S3Txsw==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -3278,6 +3290,9 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -3326,6 +3341,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@8.0.0:
+    resolution: {integrity: sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    hasBin: true
+
   smol-toml@1.3.1:
     resolution: {integrity: sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==}
     engines: {node: '>= 18'}
@@ -3370,6 +3390,9 @@ packages:
 
   stacktrace-js@2.0.2:
     resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3960,6 +3983,12 @@ snapshots:
     dependencies:
       fast-xml-parser: 5.2.5
       kleur: 4.1.5
+
+  '@astrojs/sitemap@3.4.1':
+    dependencies:
+      sitemap: 8.0.0
+      stream-replace-string: 2.0.0
+      zod: 3.24.2
 
   '@astrojs/tailwind@6.0.2(astro@5.9.4(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.40.0)(sass@1.86.3)(typescript@5.8.3)(yaml@2.7.1))(tailwindcss@3.4.17)':
     dependencies:
@@ -5202,6 +5231,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@17.0.45': {}
+
   '@types/node@22.14.1':
     dependencies:
       undici-types: 6.21.0
@@ -5223,6 +5254,10 @@ snapshots:
   '@types/sanitize-html@2.15.0':
     dependencies:
       htmlparser2: 8.0.2
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 22.14.1
 
   '@types/unist@2.0.11': {}
 
@@ -7555,6 +7590,8 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.1
 
+  sax@1.4.1: {}
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -7622,6 +7659,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@8.0.0:
+    dependencies:
+      '@types/node': 17.0.45
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.4.1
+
   smol-toml@1.3.1: {}
 
   snake-case@3.0.4:
@@ -7659,6 +7703,8 @@ snapshots:
       error-stack-parser: 2.1.4
       stack-generator: 2.0.10
       stacktrace-gps: 3.1.2
+
+  stream-replace-string@2.0.0: {}
 
   string-width@4.2.3:
     dependencies:

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -57,7 +57,7 @@ if (title) {
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@unitaryfdn">
+    <meta name="twitter:site" content="@unitaryfdn" />
     <meta property="twitter:url" content={Astro.url} />
     <meta property="twitter:title" content={metaTitle ? metaTitle : title ? title : titleName} />
     <meta property="twitter:description" content={metaDescription ? metaDescription : titleName} />
@@ -84,6 +84,12 @@ if (title) {
       title={titleName}
       href={`${Astro.url.origin}/posts/feed.xml`}
     />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="Unitary Foundation RSS Feed"
+      href={new URL("rss.xml", Astro.site)}
+    />
 
     <!-- Scripts -->
     <script
@@ -97,6 +103,9 @@ if (title) {
       integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05"
       crossorigin="anonymous"
       onload="renderMathInElement(document.body);"></script>
+
+    <!-- Sitemap -->
+    <link rel="sitemap" href="./sitemap-index.xml" />
   </head>
   <body
     class:list={[

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,65 @@
+import rss from '@astrojs/rss';
+import { z, getCollection } from 'astro:content';
+import sanitizeHtml from 'sanitize-html';
+import MarkdownIt from 'markdown-it';
+const parser = new MarkdownIt();
+
+export async function GET(context: { site: any; }) {
+  const posts = await getCollection("blog");
+  const grants = await getCollection("grant");
+
+  const RSSSchema = z.object({
+    title: z.string(),
+    link: z.string(),
+    author: z.string().optional(),
+    pubDate: z.date(),
+    tags: z.array(z.string()).optional(),
+    content: z.string().optional()
+  });
+
+  type RSSItem = z.infer<typeof RSSSchema>
+  const combined_items: RSSItem[] = []
+
+  posts.map(post => combined_items.push({
+    title: post.data.title,
+    link: `/posts/${post.slug}/`,
+    author: post.data.author,
+    pubDate: new Date(`${post.data.year || 2018}-${post.data.month || 1}-${post.data.day || 1}`),
+    tags: post.data.tags || [],
+    content: sanitizeHtml(parser.render(post.body), {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img", "p", "h1", "h2", "h3", "a", "ul", "ol", "li", "blockquote", "code", "pre", "strong"])
+    }),
+  }))
+
+  grants.map(grant => combined_items.push({
+    title: grant.data.name,
+    link: "/grants/",
+    pubDate: new Date(`${grant.data.year || 2018}-${grant.data.month || 1}-${grant.data.day || 1}`),
+    tags: grant.data.tags || [],
+    content: sanitizeHtml(parser.render(grant.body), {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img", "p", "h1", "h2", "h3", "a", "ul", "ol", "li", "blockquote", "code", "pre", "strong"])
+    }),
+  }))
+
+  combined_items.sort((a, b) => {
+    return b.pubDate.getTime() - a.pubDate.getTime()
+  })
+
+
+
+  return rss({
+    title: "Unitary Foundation Blog",
+    description: "Unitary Foundation is a non-profit working to create a quantum technology ecosystem that benefits the most people.",
+    site: context.site,
+
+    items: combined_items.slice(0, 20).map((item: RSSItem) => ({
+      title: item.title,
+      pubDate: item.pubDate,
+      author: item.author,
+      categories: item.tags || [],
+      link: item.link,
+      content: item.content,
+    })),
+  });
+
+}


### PR DESCRIPTION
PR adds:
- RSS combining blogs and grants, preliminarily limited to the last 20 entries,
- Sitemap.

The first commit is unlikely ready for merging. There is an existing RSS for blogs only. It is necessary to decide first if to keep it like that (2 RSS feeds, one for blogs, one combining blogs and grants) or use only the combined version. 

Closes #49 

@cosenal . Adding sitemap here since you need it anyway and the two things typically go hand in hand. 