### PR TITLE
Disable font ligatures

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -297,6 +297,9 @@ module.exports = {
         h2: {
           fontWeight: theme('fontWeight.semibold'),
         },
+        html: {
+          fontVariantLigatures: 'no-common-ligatures',
+        },
       });
     }),
     require('@tailwindcss/typography'),


### PR DESCRIPTION
The font [Manrope](https://fonts.google.com/specimen/Manrope) that's used throughout the website cause (c) to be shown as © (the copyright symbol), because of icon ligatures.

E.g., `501(c)(3)` is shown weirdly in many pages (in almost all browsers) because of that.

NOTE: everything is fine in the markdown-->html rendering, it's just a problem with font ligatures 🤮 If you see the page source in the browser inspector, you will see that it's actually `501(c)(3)` on the source page. 