### PR TITLE
Add Clifft research page

### DIFF
--- a/src/content/navigation/main.json
+++ b/src/content/navigation/main.json
@@ -35,6 +35,10 @@
           "link": "/research/ucc/"
         },
         {
+          "text": "Clifft",
+          "link": "/research/clifft/"
+        },
+        {
           "text": "Publications",
           "link": "/research/publications/"
         }

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -40,7 +40,7 @@ import {
         See our [FAQ](/faqs) and [previous grants](/grants).
 
     2.  ### Research
-        We do our own research to help the ecosystem as a whole. For example, we are developing [(1)mitiq](/research/mitiq), an open-source toolkit for error-mitigated quantum programming; [(2)metriq](/research/metriq), an open community platform for sharing quantum tech benchmarks; and [(3)ucc](/research/ucc), an open-source quantum compiler collection.
+        We do our own research to help the ecosystem as a whole. For example, we are developing [(1)mitiq](/research/mitiq), an open-source toolkit for error-mitigated quantum programming; [(2)metriq](/research/metriq), an open community platform for sharing quantum tech benchmarks; [(3)ucc](/research/ucc), an open-source quantum compiler collection; and [(4)clifft](/research/clifft), an open-source simulator for fast exact simulation of near-Clifford quantum circuits.
 
     3.  ### Community
         We host an open source quantum tech community that runs [hackathons](https://unitaryhack.dev) and events on our [Discord](https://discord.com/invite/JqVGmpkP96). Have a look at our [Calendar.](community/events)

--- a/src/pages/research/clifft.mdx
+++ b/src/pages/research/clifft.mdx
@@ -1,0 +1,19 @@
+---
+title: Clifft
+layout: '~/layouts/Layout.astro'
+---
+
+import { PageIntro, ReducedWidth } from '~/components/Ui';
+
+<PageIntro>
+# Fast exact simulation for near-Clifford quantum circuits.
+
+**`clifft`** helps researchers simulate early fault-tolerant circuits that are mostly Clifford but depend on localized non-Clifford operations. It accepts Stim-format circuits, extends them with non-Clifford gates, and compiles them into bytecode for a high-performance simulator, preserving the compile-once, sample-many workflow used in QEC studies while keeping the expensive dense-state work focused on the active non-Clifford dimension.
+
+</PageIntro>
+
+<ReducedWidth className="mt-12 md:mt-16">
+**Learn More and Contribute**
+
+If you'd like to chat, find us in the #clifft channel on our :social-link-discord[Discord]. Read the [documentation](https://unitaryfoundation.github.io/clifft/), try the [interactive playground](https://unitaryfoundation.github.io/clifft/playground/), read the [paper](https://arxiv.org/abs/2604.27058), or contribute on [GitHub](https://github.com/unitaryfoundation/clifft).
+</ReducedWidth>


### PR DESCRIPTION
Adds a Clifft research page, updates the homepage research copy, and adds Clifft to the Research navigation. Verification: pnpm run build.