### PR TITLE
feat(readme): update community fund readme to make it clearer

### DIFF
--- a/src/pages/community/deltakit_community_fund.mdx
+++ b/src/pages/community/deltakit_community_fund.mdx
@@ -18,6 +18,8 @@ Welcome to the **Deltakit Community Fund**! This is a joint effort between **Uni
 
 Choose a prompt on the Deltakit repository or propose an issue of your own. If you are accepted as a Community Fund Micrograntee, you will receive **up to $4k USD** in financial support as well as mentorship from both the Riverlane and Unitary Foundation teams. 
 
+Issues labelled <code>community-fund-proposal</code> in the Deltakit repository are ideas eligible for the fund, they are proposals and not accepted projects. Any of these issues that isn't yet assigned to anyone can be used as part of your application.
+
 ---
 
 <p class="text-2xl mb-3">How to Get Started</p>
@@ -29,13 +31,13 @@ Choose a prompt on the Deltakit repository or propose an issue of your own. If y
   <span>Save your link to add to your application (in Step 4):</span>
   <ul className="list-disc ml-6">
     <li>For existing issues, copy the issue URL.</li>
-    <li>If you have your own idea, create an issue in the Deltakit repo and save that link.</li>
+    <li>If you have your own idea, create an issue in the Deltakit repo and save that link. We triage new issues regularly: if we don't think an issue is eligible for the fund, we'll comment on it and won't apply the <code>community-fund-proposal</code> label. You're welcome to revise your proposal or open a new issue. Keep in mind that any issue you create is open for other candidates to propose on too, though as its author you may well have the strongest interest and solution.</li>
   </ul>
 </li>
   <li>Submit your application using the form below.</li>
 </ol>
 
-<ButtonLink url="https://github.com/Deltakit/deltakit/issues?q=is:issue%20state:open%20label:community-fund">Browse Deltakit Issues</ButtonLink>
+<ButtonLink url="https://github.com/Deltakit/deltakit/issues?q=is:issue%20state:open%20label:community-fund-proposal%20no:assignee">Browse Deltakit Issues</ButtonLink>
 
 <ButtonLink url="https://forms.gle/VxeJZhtSuRMRjpSaA">Apply for the Grant</ButtonLink>
 
@@ -44,7 +46,7 @@ Choose a prompt on the Deltakit repository or propose an issue of your own. If y
 <p class="text-2xl mb-3">Answers to Frequently Asked Questions</p>
 
 ### Review Timeline
-Grants are awarded on a rolling basis. The committee reconvenes each month to review incoming applications. The very first review will take place the week of August 17th, 2026. 
+Grants are awarded on a rolling basis. The committee reconvenes regularly to review incoming applications. The very first review will take place the week of August 17th, 2026. 
 
 ### Grant Period
 If you are chosen to receive a grant, your project footprint can range anywhere between **1 to 2 quarters (3–6 months)**. 

--- a/src/pages/community/deltakit_community_fund.mdx
+++ b/src/pages/community/deltakit_community_fund.mdx
@@ -12,7 +12,7 @@ import {
   <img src="/images/deltakit_banner.png" style="width: 100%" alt="deltakit banner"/>
 </p>
 
-<p class="text-3xl font-bold"><mark>DeltaKit</mark> Community Fund</p>
+<p class="text-3xl font-bold"><mark>Deltakit</mark> Community Fund</p>
 
 Welcome to the **Deltakit Community Fund**! This is a joint effort between **Unitary Foundation** and **Riverlane** to support researchers and quantum developers who'd like to contribute to [Deltakit](https://www.riverlane.com/deltakit), Riverlane's open-source Quantum Error Correction (QEC) software.
 

--- a/src/pages/community/deltakit_community_fund.mdx
+++ b/src/pages/community/deltakit_community_fund.mdx
@@ -31,7 +31,7 @@ Issues labelled <code>community-fund-proposal</code> in the Deltakit repository 
   <span>Save your link to add to your application (in Step 4):</span>
   <ul className="list-disc ml-6">
     <li>For existing issues, copy the issue URL.</li>
-    <li>If you have your own idea, create an issue in the Deltakit repo and save that link. We triage new issues regularly: if we don't think an issue is eligible for the fund, we'll comment on it and won't apply the <code>community-fund-proposal</code> label. You're welcome to revise your proposal or open a new issue. Keep in mind that any issue you create is open for other candidates to propose on too, though as its author you may well have the strongest interest and solution.</li>
+    <li>If you have your own idea, create an issue in the Deltakit repo. We triage new issues regularly: if we don't think an issue is eligible for the fund, we'll comment on it and won't apply the <code>community-fund-proposal</code> label. You're welcome to revise your proposal or open a new issue. Keep in mind that any issue you create is open for other candidates to propose on too, though as its author you may well have the strongest interest and solution.</li>
   </ul>
 </li>
   <li>Submit your application using the form below.</li>


### PR DESCRIPTION
Update [Deltakit Community blog post](https://unitary.foundation/community/deltakit_community_fund/) to make the process of issue triage and GitHub tag meaning clearer.