### PR TITLE
Fix Mailchimp embedded form

### DIFF
--- a/src/components/Layout/Footer.astro
+++ b/src/components/Layout/Footer.astro
@@ -15,12 +15,13 @@ import ContentCredit from './Footer/Content/credit.md';
         <Section title="Stay updated on our work">
           <div class="flex flex-col gap-6">
             <form
-              action="https://mailchi.mp/46a677be77cd/uf"
+              action="https://foundation.us18.list-manage.com/subscribe/post?u=104796c75ced8350ebd01eebd&amp;id=a2c9e5ac2a&amp;f_id=0091b0e6f0"
               method="post"
               name="mc-embedded-subscribe-form"
               class="validate"
               target="_blank"
-              novalidate="">
+              novalidate=""
+            >
               <MiniFormLayout>
                 <input
                   slot="input"
@@ -31,8 +32,15 @@ import ContentCredit from './Footer/Content/credit.md';
                   class="w-full placeholder:text-inherit"
                   required
                 />
-                <input slot="button" type="submit" value="Subscribe" name="subscribe" />
+
+                <input
+                  slot="button"
+                  type="submit"
+                  value="Subscribe"
+                  name="subscribe"
+                />
               </MiniFormLayout>
+
               <div style="position: absolute; left: -5000px" aria-hidden="true">
                 <input
                   type="text"


### PR DESCRIPTION
Fix issue well-spotted by Ian Nanez.

Context:
The newsletter signup in the footer used to post directly to Mailchimp's subscription endpoint. In August 2025, the form action was changed first to the public Bitly signup link and then to the `mailchi.mp` landing page URL. While those URLs work as regular links, they are not valid form POST endpoints, causing submissions from the footer to fail with an authentication error.

This restores the Mailchimp subscription endpoint using the current embedded-form configuration.