### PR TITLE
Load Cloudinary config for image directives

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,7 +15,14 @@ import {
   socialDirective,
 } from './src/remark/directives';
 import remarkOnlyStrong from './src/remark/only-strong';
+import { loadEnv } from 'vite';
 import svgr from 'vite-plugin-svgr';
+
+const { PUBLIC_CLOUDINARY_CLOUD_NAME } = loadEnv(
+  process.env.NODE_ENV ?? 'development',
+  process.cwd(),
+  '',
+);
 
 // https://astro.build/config
 export default defineConfig({
@@ -51,7 +58,7 @@ export default defineConfig({
       ],
       remarkDirective,
       remarkMath,
-      imageDirective,
+      [imageDirective, { cloudName: PUBLIC_CLOUDINARY_CLOUD_NAME }],
       gistDirective,
       socialDirective,
     ],

--- a/src/remark/directives.ts
+++ b/src/remark/directives.ts
@@ -2,11 +2,20 @@ import 'remark-directive';
 import type { Plugin } from 'unified';
 import type { Root } from 'mdast';
 import { visit } from 'unist-util-visit';
+import { Cloudinary } from '@cloudinary/url-gen';
 import { Resize } from '@cloudinary/url-gen/actions/resize';
-import { cld } from '../util/cloudinary';
 import socialLinks from '../data/social.json';
 
-export const imageDirective: Plugin<[], Root> = () => {
+type ImageDirectiveOptions = {
+  cloudName: string;
+};
+
+export const imageDirective: Plugin<[ImageDirectiveOptions], Root> = ({ cloudName }) => {
+  const cld = new Cloudinary({
+    cloud: { cloudName },
+    url: { secure: true },
+  });
+
   return (tree, file) => {
     visit(tree, (node) => {
       if (


### PR DESCRIPTION
## Summary

- load `PUBLIC_CLOUDINARY_CLOUD_NAME` while Astro evaluates its configuration
- pass the cloud name explicitly to the remark image directive
- give the build-time directive its own configured Cloudinary client instead of importing the application-time client

## Root cause

The variable was already configured in Vercel. The image directive imports the shared Cloudinary client through `astro.config.mjs`, but Astro evaluates configuration before application variables are exposed through `import.meta.env`. As a result, the directive initialized Cloudinary without a cloud name and content sync dropped the affected post body.

This follows Astro’s documented config-time environment pattern: https://docs.astro.build/en/guides/environment-variables/#in-the-astro-config-file

## Verification

- reproduced the original failure with `PUBLIC_CLOUDINARY_CLOUD_NAME` explicitly present
- verified config-time loading from both a process environment variable (Vercel/GitHub Actions) and a local `.env` file
- built an isolated `::image[lzti0pc4eriguxndob9w]` post and verified its surrounding text plus the generated `c_scale,w_800` Cloudinary URL
- `pnpm build` (315 pages)